### PR TITLE
fix: macos docker file files due to group id conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ export GOARCH=amd64
 # containerization and volume mounting
 export HOST_USER_UID=$(shell id -u)
 export HOST_USER_GID=$(shell id -g)
+export OS_NAME=$(shell uname -s | tr A-Z a-z)
 
 
 # initialize services

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
         GOHAN_API_INTERNAL_PORT: ${GOHAN_API_INTERNAL_PORT} 
         HOST_USER_UID: ${HOST_USER_UID}
         HOST_USER_GID: ${HOST_USER_GID}
+        OS_NAME: ${OS_NAME}
     mem_limit: ${GOHAN_API_MEM_LIM} # for mem_limit to work, make sure docker-compose is v2.4
     cpus: ${GOHAN_API_CPUS}
     cpu_shares: 1024
@@ -88,6 +89,7 @@ services:
         BASE_IMAGE_VERSION: ${GOHAN_ES_BASE_VERSION}
         HOST_USER_UID: ${HOST_USER_UID}
         HOST_USER_GID: ${HOST_USER_GID}
+        OS_NAME: ${OS_NAME}
     mem_limit: ${GOHAN_ES_MEM_LIM} # for mem_limit to work, make sure docker-compose is v2.4
     cpus: ${GOHAN_ES_CPUS}
     cpu_shares: 2048

--- a/drs/Dockerfile
+++ b/drs/Dockerfile
@@ -67,7 +67,11 @@ RUN ["pip", "install", "-r", "requirements.txt"]
 # Security :
 ARG HOST_USER_UID
 ARG HOST_USER_GID
-RUN addgroup -S drsgroup -g $HOST_USER_GID && \
+ARG OS_NAME
+RUN if [ $OS_NAME != darwin ]; \
+    then addgroup -S drsgroup -g $HOST_USER_GID; \
+	else addgroup -S drsgroup; \
+	fi && \
     adduser -S drsuser -u $HOST_USER_UID -G drsgroup
 
 USER drsuser

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -5,7 +5,11 @@ FROM "${BASE_IMAGE}:${BASE_IMAGE_VERSION}"
 
 ARG HOST_USER_UID
 ARG HOST_USER_GID
-RUN groupadd --system elasticsearchgroup -g $HOST_USER_GID && \
+ARG OS_NAME
+RUN if [ $OS_NAME != darwin ]; \
+    then groupadd --system elasticsearchgroup -g $HOST_USER_GID; \
+    else groupadd --system elasticsearchgroup; \
+    fi && \
     usermod -a -G elasticsearchgroup elasticsearch
 
 USER elasticsearch

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -63,7 +63,11 @@ RUN apk update && \
 # Security :
 ARG HOST_USER_UID
 ARG HOST_USER_GID
-RUN addgroup -S apigroup -g $HOST_USER_GID && \
+ARG OS_NAME
+RUN if [ $OS_NAME != darwin ]; \
+    then addgroup -S apigroup -g $HOST_USER_GID; \
+    else addgroup -S apigroup; \
+    fi && \
     adduser -S apiuser -u $HOST_USER_UID -G apigroup
 
 USER apiuser


### PR DESCRIPTION
Fixes issue with MacOSX group creation in Docker files. Heavily inspired by the following commit and the corresponding bug report: https://github.com/pyro-ppl/pyro/pull/719/commits/5b3da259c69b87afdf64e0a5425f8c9827ecf354