### PR TITLE
Features/genotype spec

### DIFF
--- a/src/api/models/schemas/schemas.go
+++ b/src/api/models/schemas/schemas.go
@@ -176,8 +176,6 @@ var VARIANT_CALL_SCHEMA Schema = map[string]interface{}{
 		"genotype_type": map[string]interface{}{
 			"description": "Variant call genotype type.",
 			"enum": []string{
-				"MISSING",
-				"MISSING_UPSTREAM_DELETION",
 				"REFERENCE",
 				"ALTERNATE",
 				"HOMOZYGOUS_REFERENCE",

--- a/src/api/models/schemas/schemas.go
+++ b/src/api/models/schemas/schemas.go
@@ -189,7 +189,7 @@ var VARIANT_CALL_SCHEMA Schema = map[string]interface{}{
 				},
 				"order":     2.0,
 				"queryable": "all",
-				"required":  true,
+				"required":  false,
 				"type":      "single",
 			},
 			"type": "string",


### PR DESCRIPTION
Changes to variant search spec (both Redmine [#1402](https://206.12.92.46/issues/1402)):
- make `genotype_type` optional in search 
- remove `genotype_type` values `MISSING` and `MISSING_UPSTREAM_DELETION`