### PR TITLE
Ploidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
   # move vcf.gz files to `$GOHAN_API_VCF_PATH`
 
   # ingest vcf.gz
-  curl -k https://gohan.local/variants/ingestion/run\?fileNames=<filename>\&assemblyId=GRCh37\&filterOutHomozygousReferences=true\&tableId=<table id>
+  curl -k https://gohan.local/variants/ingestion/run\?fileNames=<filename>\&assemblyId=GRCh37\&filterOutReferences=true\&tableId=<table id>
   
   # monitor progress:
   curl -k https://gohan.local/variants/ingestion/requests

--- a/src/api/models/constants/main.go
+++ b/src/api/models/constants/main.go
@@ -4,10 +4,10 @@ var ValidTableDataTypes = []string{"variant"}
 var VcfHeaders = []string{"chrom", "pos", "id", "ref", "alt", "qual", "filter", "info", "format"}
 
 /*
-	Defines a set of base level
-	constants and enums to be used
-	throughout Gohan and it's
-	associated services.
+Defines a set of base level
+constants and enums to be used
+throughout Gohan and it's
+associated services.
 */
 type AssemblyId string
 type Chromosome string
@@ -16,3 +16,4 @@ type SearchOperation string
 type SortDirection string
 
 type Zygosity int
+type Ploidy int

--- a/src/api/models/constants/ploidy/main.go
+++ b/src/api/models/constants/ploidy/main.go
@@ -1,0 +1,16 @@
+package ploidy
+
+import (
+	"gohan/api/models/constants"
+)
+
+const (
+	Unknown constants.Ploidy = iota
+
+	Haploid
+	Diploid
+)
+
+func IsKnown(value int) bool {
+	return value > int(Unknown) && value <= int(Diploid)
+}

--- a/src/api/models/constants/zygosity/main.go
+++ b/src/api/models/constants/zygosity/main.go
@@ -6,23 +6,35 @@ import (
 
 const (
 	Unknown constants.Zygosity = iota
+	// Diploid or higher
 	Heterozygous
 	HomozygousReference
 	HomozygousAlternate
+
+	// Haploid (deliberately below diploid for sequential id'ing purposes)
+	Reference
+	Alternate
 )
 
 func IsKnown(value int) bool {
-	return value > int(Unknown) && value <= int(HomozygousAlternate)
+	return value > int(Unknown) && value <= int(Alternate)
 }
 
 func ZygosityToString(zyg constants.Zygosity) string {
 	switch zyg {
+	// Haploid
+	case Reference:
+		return "REFERENCE"
+	case Alternate:
+		return "ALTERNATE"
+
+	// Diploid or higher
 	case Heterozygous:
 		return "HETEROZYGOUS"
-	case HomozygousAlternate:
-		return "HOMOZYGOUS_ALTERNATE"
 	case HomozygousReference:
 		return "HOMOZYGOUS_REFERENCE"
+	case HomozygousAlternate:
+		return "HOMOZYGOUS_ALTERNATE"
 	default:
 		return "UNKNOWN"
 	}

--- a/src/api/mvc/variants/main.go
+++ b/src/api/mvc/variants/main.go
@@ -237,14 +237,14 @@ func VariantsIngest(c echo.Context) error {
 
 	// -- optional filter
 	var (
-		filterOutHomozygousReferences bool = false // default
-		fohrErr                       error
+		filterOutReferences bool = false // default
+		fohrErr             error
 	)
-	filterOutHomozygousReferencesQP := c.QueryParam("filterOutHomozygousReferences")
-	if len(filterOutHomozygousReferencesQP) > 0 {
-		filterOutHomozygousReferences, fohrErr = strconv.ParseBool(filterOutHomozygousReferencesQP)
+	filterOutReferencesQP := c.QueryParam("filterOutReferences")
+	if len(filterOutReferencesQP) > 0 {
+		filterOutReferences, fohrErr = strconv.ParseBool(filterOutReferencesQP)
 		if fohrErr != nil {
-			fmt.Printf("Error parsing filterOutHomozygousReferences: %s, [%s] - defaulting to 'false'\n", filterOutHomozygousReferencesQP, fohrErr)
+			fmt.Printf("Error parsing filterOutReferences: %s, [%s] - defaulting to 'false'\n", filterOutReferencesQP, fohrErr)
 			// defaults to false
 		}
 	}
@@ -435,7 +435,7 @@ func VariantsIngest(c echo.Context) error {
 				// ---	 load vcf into memory and ingest the vcf file into elasticsearch
 				beginProcessingTime := time.Now()
 				fmt.Printf("Begin processing %s at [%s]\n", gzippedFilePath, beginProcessingTime)
-				ingestionService.ProcessVcf(gzippedFilePath, drsFileId, tableId, assemblyId, filterOutHomozygousReferences, cfg.Api.LineProcessingConcurrencyLevel)
+				ingestionService.ProcessVcf(gzippedFilePath, drsFileId, tableId, assemblyId, filterOutReferences, cfg.Api.LineProcessingConcurrencyLevel)
 				fmt.Printf("Ingest duration for file at %s : %s\n", gzippedFilePath, time.Since(beginProcessingTime))
 
 				reqStat.State = ingest.Done

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -748,7 +748,6 @@ func addZygosityToMustMap(genotype c.GenotypeQuery, mustMap []map[string]interfa
 		}
 	}
 
-	// Not all genotype-queries are compatible yet, i.e. Haploid types `REFERENCE` and `ALTERNATE`
 	// - verify zygosity-map is not empty before adding to the must-map
 	if len(zygosityMatchMap) > 0 {
 		mustMap = append(mustMap, map[string]interface{}{

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -669,13 +669,7 @@ func addAllelesToShouldMap(alleles []string, genotype c.GenotypeQuery, allelesSh
 				// queried allele should be present on the left side of the pair with an empty right side
 				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
 					"query_string": map[string]interface{}{
-						"fields": []string{"sample.variation.alleles.left.keyword"},
-						"query":  alleles[0],
-					}})
-				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
-					"query_string": map[string]interface{}{
-						"fields": []string{"sample.variation.alleles.right.keyword"},
-						"query":  "",
+						"query": "sample.variation.alleles.left.keyword:" + alleles[0] + " AND sample.variation.alleles.right.keyword:\"\"",
 					}})
 
 			} else {

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -152,7 +152,7 @@ func GetDocumentsContainerVariantOrSampleIdInPositionRange(cfg *models.Config, e
 			}})
 	}
 
-	shouldMap, minimumShouldMatch = addAllelesToShouldMap(alleles, shouldMap)
+	shouldMap, minimumShouldMatch = addAllelesToShouldMap(alleles, genotype, shouldMap)
 
 	if reference != "" {
 		mustMap = append(mustMap, map[string]interface{}{
@@ -367,7 +367,7 @@ func CountDocumentsContainerVariantOrSampleIdInPositionRange(cfg *models.Config,
 			}})
 	}
 
-	shouldMap, minimumShouldMatch = addAllelesToShouldMap(alleles, shouldMap)
+	shouldMap, minimumShouldMatch = addAllelesToShouldMap(alleles, genotype, shouldMap)
 
 	if reference != "" {
 		mustMap = append(mustMap, map[string]interface{}{
@@ -657,27 +657,65 @@ func DeleteVariantsByTableId(es *es7.Client, cfg *models.Config, tableId string)
 
 // -- internal use only --
 
-func addAllelesToShouldMap(alleles []string, allelesShouldMap []map[string]interface{}) ([]map[string]interface{}, int) {
+func addAllelesToShouldMap(alleles []string, genotype c.GenotypeQuery, allelesShouldMap []map[string]interface{}) ([]map[string]interface{}, int) {
 	minimumShouldMatch := 0
 
 	if len(alleles) > 0 {
 		switch len(alleles) {
 		case 1:
-			// any allele can be present on either side of the pair
-			allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
-				"query_string": map[string]interface{}{
-					"query": "sample.variation.alleles.left.keyword:" + alleles[0] + " OR sample.variation.alleles.right.keyword:" + alleles[0],
-				}})
+			if genotype == gq.ALTERNATE || genotype == gq.REFERENCE {
+				// haploid case
+
+				// queried allele should be present on the left side of the pair with an empty right side
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"fields": []string{"sample.variation.alleles.left.keyword"},
+						"query":  alleles[0],
+					}})
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"fields": []string{"sample.variation.alleles.right.keyword"},
+						"query":  "",
+					}})
+
+			} else {
+				// assume diploid-type of search as default
+
+				//  queried allele can be present on either side of the pair
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"query": "sample.variation.alleles.left.keyword:" + alleles[0] + " OR sample.variation.alleles.right.keyword:" + alleles[0],
+					}})
+			}
 		case 2:
-			// treat as a left/right pair
-			allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
-				"query_string": map[string]interface{}{
-					"query": "sample.variation.alleles.left.keyword:" + alleles[0] + " AND sample.variation.alleles.right.keyword:" + alleles[1],
-				}})
-			allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
-				"query_string": map[string]interface{}{
-					"query": "sample.variation.alleles.left.keyword:" + alleles[1] + " AND sample.variation.alleles.right.keyword:" + alleles[0],
-				}})
+			if genotype == gq.ALTERNATE || genotype == gq.REFERENCE {
+				// haploid case
+
+				// either queried allele can be present on the left side of the pair with an empty right side
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"query": "sample.variation.alleles.left.keyword:" + alleles[0] + " AND sample.variation.alleles.right.keyword:\"\"",
+					}})
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"query": "sample.variation.alleles.left.keyword:" + alleles[1] + " AND sample.variation.alleles.right.keyword:\"\"",
+					}})
+
+			} else {
+				// assume diploid-type of search as default
+
+				// treat as a left/right pair
+				// either queried allele can be present on the left or right side of the pair
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"query": "sample.variation.alleles.left.keyword:" + alleles[0] + " AND sample.variation.alleles.right.keyword:" + alleles[1],
+					}})
+				allelesShouldMap = append(allelesShouldMap, map[string]interface{}{
+					"query_string": map[string]interface{}{
+						"query": "sample.variation.alleles.left.keyword:" + alleles[1] + " AND sample.variation.alleles.right.keyword:" + alleles[0],
+					}})
+			}
+			// TODO: triploid ?
 		}
 		minimumShouldMatch = 1
 	}

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -689,6 +689,17 @@ func addZygosityToMustMap(genotype c.GenotypeQuery, mustMap []map[string]interfa
 	zygosityMatchMap := make(map[string]interface{})
 
 	switch genotype {
+	// Haploid
+	case gq.REFERENCE:
+		zygosityMatchMap["sample.variation.genotype.zygosity"] = map[string]interface{}{
+			"query": z.Reference,
+		}
+
+	case gq.ALTERNATE:
+		zygosityMatchMap["sample.variation.genotype.zygosity"] = map[string]interface{}{
+			"query": z.Alternate,
+		}
+	// Diploid
 	case gq.HETEROZYGOUS:
 		zygosityMatchMap["sample.variation.genotype.zygosity"] = map[string]interface{}{
 			"query": z.Heterozygous,

--- a/src/api/services/ingestion.go
+++ b/src/api/services/ingestion.go
@@ -342,7 +342,7 @@ func (i *IngestionService) UploadVcfGzToDrs(cfg *models.Config, drsBridgeDirecto
 
 func (i *IngestionService) ProcessVcf(
 	gzippedFilePath string, drsFileId string, tableId string,
-	assemblyId constants.AssemblyId, filterOutHomozygousReferences bool,
+	assemblyId constants.AssemblyId, filterOutReferences bool,
 	lineProcessingConcurrencyLevel int) {
 
 	// ---   reopen gzipped file after having been copied to the temporary api-drs
@@ -527,7 +527,7 @@ func (i *IngestionService) ProcessVcf(
 						// support for multi-sampled calls
 						// assume first component of allValues is the genotype
 						genoTypeValue := allValues[0]
-						if filterOutHomozygousReferences &&
+						if filterOutReferences &&
 							(genoTypeValue == "0" || // haploid type references
 								genoTypeValue == "0|0" || genoTypeValue == "0/0") { // diploid type homezygous references
 							// skip adding this sample to the 'tmpSamples' list which

--- a/src/api/services/ingestion.go
+++ b/src/api/services/ingestion.go
@@ -527,7 +527,9 @@ func (i *IngestionService) ProcessVcf(
 						// support for multi-sampled calls
 						// assume first component of allValues is the genotype
 						genoTypeValue := allValues[0]
-						if filterOutHomozygousReferences && (genoTypeValue == "0|0" || genoTypeValue == "0/0") {
+						if filterOutHomozygousReferences &&
+							(genoTypeValue == "0" || // haploid type references
+								genoTypeValue == "0|0" || genoTypeValue == "0/0") { // diploid type homezygous references
 							// skip adding this sample to the 'tmpSamples' list which
 							// then goes to be further processed into a variant document
 
@@ -839,7 +841,7 @@ func (i *IngestionService) ProcessVcf(
 	// let all lines be queued up and processed
 	_fileWG.Wait()
 
-	fmt.Printf("File %s waited for and complete!\n\t- Number of skipped Homozygous Reference calls: %d\n", gzippedFilePath, skippedHomozygousReferencesCount)
+	fmt.Printf("File %s waited for and complete!\n\t- Number of skipped Reference and/or Homozygous-Reference calls: %d\n", gzippedFilePath, skippedHomozygousReferencesCount)
 }
 
 func (i *IngestionService) FilenameAlreadyRunning(filename string) bool {

--- a/src/api/services/ingestion.go
+++ b/src/api/services/ingestion.go
@@ -11,6 +11,7 @@ import (
 	"gohan/api/models"
 	"gohan/api/models/constants"
 	"gohan/api/models/constants/chromosome"
+	p "gohan/api/models/constants/ploidy"
 	z "gohan/api/models/constants/zygosity"
 	"gohan/api/models/ingest"
 	"gohan/api/models/ingest/structs"
@@ -605,69 +606,130 @@ func (i *IngestionService) ProcessVcf(
 						// create genotype from value
 						gtString := tmpValueStrings[k]
 
-						phased := strings.Contains(gtString, "|")
+						var ploidy constants.Ploidy
+						// as defined by
+						// https://samtools.github.io/hts-specs/VCFv4.1.pdf , page 25
+						//		"...
+						//		 0 		as a haploid it is represented by a single byte 	0x02
+						//		 1 		as a haploid it is represented by a single byte 	0x04
+						//		..."
+
+						// determine ploidy
+						if !strings.Contains(gtString, "|") && !strings.Contains(gtString, "/") {
+							ploidy = p.Haploid
+						} else {
+							// assume number of "|" or "/" present is 1
+							ploidy = p.Diploid
+						}
+						// TODO: handle triploid?
 
 						var (
+							zyg                constants.Zygosity
+							phased             bool
 							alleleStringSplits []string
 							alleleLeft         int = -1
 							alleleRight        int = -1
 							errLeft            error
 							errRight           error
 						)
-						if phased {
-							alleleStringSplits = strings.Split(gtString, "|")
-						} else {
-							alleleStringSplits = strings.Split(gtString, "/")
-						}
 
-						switch len(alleleStringSplits) {
-						case 1:
-							if alleleStringSplits[0] == "." {
+						switch ploidy {
+						case p.Haploid:
+							// handle haploid
+
+							// -- allele
+							//		piggy-back off of diploid implementation and use
+							//		alleleLeft to store the haploid single allele
+							if gtString == "." {
 								alleleLeft = 0
 							} else {
 								// -- if error, probably an unknown character -- assign -1
-								alleleLeft, errLeft = strconv.Atoi(alleleStringSplits[0])
+								alleleLeft, errLeft = strconv.Atoi(gtString)
 								if errLeft != nil {
 									alleleLeft = -1
 								}
 							}
-						case 2:
-							// convert string to int
-							// - check and handle when 'gtString' contains '.'s
-							if alleleStringSplits[0] == "." && alleleStringSplits[1] == "." {
-								alleleLeft = 0
-								alleleRight = 0
+
+							// -- zygosity:
+							if alleleLeft == -1 {
+								zyg = z.Unknown
 							} else {
-								// -- if error, probably an unknown character -- assign -1
-								alleleLeft, errLeft = strconv.Atoi(alleleStringSplits[0])
-								if errLeft != nil {
-									alleleLeft = -1
-								}
-
-								alleleRight, errRight = strconv.Atoi(alleleStringSplits[1])
-								if errRight != nil {
-									alleleRight = -1
-								}
-							}
-							// default (0) : let default -1 and -1 be handled
-						}
-
-						// -- zygosity:
-						var zyg constants.Zygosity
-						if alleleLeft == -1 || alleleRight == -1 {
-							zyg = z.Unknown
-						} else {
-							switch alleleLeft == alleleRight {
-							case true:
-								switch alleleLeft * alleleRight {
-								case 0:
-									zyg = z.HomozygousReference
+								switch alleleLeft {
 								default:
-									zyg = z.HomozygousAlternate
+									zyg = z.Alternate
+									// covers 1 and greater
+
+								case 0:
+									zyg = z.Reference
 								}
-							case false:
-								zyg = z.Heterozygous
 							}
+
+						case p.Diploid:
+							// handle diploid
+
+							// -- phase
+							phased := strings.Contains(gtString, "|")
+
+							if phased {
+								alleleStringSplits = strings.Split(gtString, "|")
+							} else {
+								alleleStringSplits = strings.Split(gtString, "/")
+							}
+
+							// -- alleles
+							switch len(alleleStringSplits) {
+							case 1:
+								if alleleStringSplits[0] == "." {
+									alleleLeft = 0
+								} else {
+									// -- if error, probably an unknown character -- assign -1
+									alleleLeft, errLeft = strconv.Atoi(alleleStringSplits[0])
+									if errLeft != nil {
+										alleleLeft = -1
+									}
+								}
+							case 2:
+								// convert string to int
+								// - check and handle when 'gtString' contains '.'s
+								if alleleStringSplits[0] == "." && alleleStringSplits[1] == "." {
+									alleleLeft = 0
+									alleleRight = 0
+								} else {
+									// -- if error, probably an unknown character -- assign -1
+									alleleLeft, errLeft = strconv.Atoi(alleleStringSplits[0])
+									if errLeft != nil {
+										alleleLeft = -1
+									}
+
+									alleleRight, errRight = strconv.Atoi(alleleStringSplits[1])
+									if errRight != nil {
+										alleleRight = -1
+									}
+								}
+								// default (0) : let default -1 and -1 be handled
+							}
+
+							// -- zygosity:
+							if alleleLeft == -1 || alleleRight == -1 {
+								zyg = z.Unknown
+							} else {
+								switch alleleLeft == alleleRight {
+								case true:
+									switch alleleLeft * alleleRight {
+									case 0:
+										zyg = z.HomozygousReference
+									default:
+										zyg = z.HomozygousAlternate
+									}
+								case false:
+									zyg = z.Heterozygous
+								}
+							}
+
+							// TODO: handle triploid?
+
+							// default:
+							// 	// error ?
 						}
 
 						//   By this point, tmpVariant["alt"] is populated with
@@ -692,10 +754,13 @@ func (i *IngestionService) ProcessVcf(
 						} else {
 							alleles.Left = tmpVariantRef[0]
 						}
-						if alleleRight > 0 {
-							alleles.Right = tmpVariantAlt[alleleRight-1]
-						} else {
-							alleles.Right = tmpVariantRef[0]
+
+						if ploidy == p.Diploid {
+							if alleleRight > 0 {
+								alleles.Right = tmpVariantAlt[alleleRight-1]
+							} else {
+								alleles.Right = tmpVariantRef[0]
+							}
 						}
 
 						variation.Genotype = indexes.Genotype{

--- a/src/api/tests/integration/api/api_capacity_test.go
+++ b/src/api/tests/integration/api/api_capacity_test.go
@@ -45,7 +45,7 @@ package api
 // 			defer _combWg.Done()
 // 			defer func() { <-simultaneousRequestsQueue }()
 
-// 			url := cfg.Api.Url + fmt.Sprintf("/variants/ingestion/run?fileNames=%s&assemblyId=GRCH37&filterOutHomozygousReferences=true", _vcfgz)
+// 			url := cfg.Api.Url + fmt.Sprintf("/variants/ingestion/run?fileNames=%s&assemblyId=GRCH37&filterOutReferences=true", _vcfgz)
 
 // 			fmt.Printf("Calling %s\n", url)
 // 			request, _ := http.NewRequest("GET", url, nil)

--- a/src/api/tests/integration/api/api_variant_test.go
+++ b/src/api/tests/integration/api/api_variant_test.go
@@ -204,6 +204,16 @@ func TestCanGetVariantsInDescendingPositionOrder(t *testing.T) {
 	})
 }
 
+func TestCanGetReferenceSamples(t *testing.T) {
+	// trigger
+	runAndValidateGenotypeQueryResults(t, gq.REFERENCE, validateReferenceSample)
+}
+
+func TestCanGetAlternateSamples(t *testing.T) {
+	// trigger
+	runAndValidateGenotypeQueryResults(t, gq.ALTERNATE, validateAlternateSample)
+}
+
 func TestCanGetHeterozygousSamples(t *testing.T) {
 	// trigger
 	runAndValidateGenotypeQueryResults(t, gq.HETEROZYGOUS, validateHeterozygousSample)
@@ -799,18 +809,23 @@ func makeGetVariantsCall(url string, ignoreStatusCode bool, _t *testing.T) dtos.
 }
 
 // --- sample validation
+func validateReferenceSample(__t *testing.T, call *dtos.VariantCall) {
+	assert.True(__t, call.GenotypeType == z.ZygosityToString(z.Reference))
+}
+
+func validateAlternateSample(__t *testing.T, call *dtos.VariantCall) {
+	assert.True(__t, call.GenotypeType == z.ZygosityToString(z.Alternate))
+}
+
 func validateHeterozygousSample(__t *testing.T, call *dtos.VariantCall) {
-	// assert.True(__t, sample.Variation.Genotype.Zygosity == z.Heterozygous)
 	assert.True(__t, call.GenotypeType == z.ZygosityToString(z.Heterozygous))
 }
 
 func validateHomozygousReferenceSample(__t *testing.T, call *dtos.VariantCall) {
-	// assert.True(__t, sample.Variation.Genotype.Zygosity == z.HomozygousReference)
 	assert.True(__t, call.GenotypeType == z.ZygosityToString(z.HomozygousReference))
 }
 
 func validateHomozygousAlternateSample(__t *testing.T, call *dtos.VariantCall) {
-	// assert.True(__t, sample.Variation.Genotype.Zygosity == z.HomozygousAlternate)
 	assert.True(__t, call.GenotypeType == z.ZygosityToString(z.HomozygousAlternate))
 }
 

--- a/src/api/workflows/main.go
+++ b/src/api/workflows/main.go
@@ -30,7 +30,7 @@ var WORKFLOW_VARIANT_SCHEMA WorkflowSchema = map[string]interface{}{
 					"default":  "GRCh38",
 				},
 				{
-					"id":       "filter_out_homozygous_references",
+					"id":       "filter_out_references",
 					"type":     "enum",
 					"required": true,
 					"values":   []string{"true", "false"}, // simulate boolean type

--- a/src/api/workflows/vcf_gz.wdl
+++ b/src/api/workflows/vcf_gz.wdl
@@ -4,7 +4,7 @@ workflow vcf_gz {
     Array[String] original_vcf_gz_file_paths
     String assembly_id
     String table_id
-    String filter_out_homozygous_references
+    String filter_out_references
     String temp_token
     String temp_token_host
 
@@ -15,7 +15,7 @@ workflow vcf_gz {
                    vcf_gz_file_name = file_name,
                    assembly_id = assembly_id,
                    table_id = table_id,
-                   filter_out_homozygous_references = filter_out_homozygous_references,
+                   filter_out_references = filter_out_references,
                    temp_token = temp_token,
                    temp_token_host = temp_token_host
 
@@ -28,14 +28,14 @@ task vcf_gz_gohan {
     String vcf_gz_file_name
     String assembly_id
     String table_id
-    String filter_out_homozygous_references
+    String filter_out_references
     String temp_token
     String temp_token_host
 
     command {
         echo "Using temporary-token : ${temp_token}"
 
-        QUERY="fileNames=${vcf_gz_file_name}&assemblyId=${assembly_id}&tableId=${table_id}&filterOutHomozygousReferences=${filter_out_homozygous_references}"
+        QUERY="fileNames=${vcf_gz_file_name}&assemblyId=${assembly_id}&tableId=${table_id}&filterOutReferences=${filter_out_references}"
         
         # TODO: refactor
         # append temporary-token header if present


### PR DESCRIPTION
Implements concept of 'ploidy', supporting haploid and diploid genotypes
- vcf ingestion
- elasticsearch querying
- adapting `filterOutHomozygousReferences` to `filterOutReferences` to cover both genotype cases under a single parameter `(breaking change)`

Due to an earlier merge, this also includes ;
- a handy parameter `directory` for variants to quickly define a whole directory to ingest
- mechanisms to distribute variants across multiple indexes (see https://github.com/bento-platform/gohan/pull/41, anticipating merge conflicts) `(breaking change)`