### PR TITLE
Features/retrieve_last_ingested

### DIFF
--- a/src/api/main.go
+++ b/src/api/main.go
@@ -134,7 +134,6 @@ func main() {
 
 	// -- Data-Types
 	e.GET("/data-types", dataTypesMvc.GetDataTypes)
-	e.GET("/public/data-types", dataTypesMvc.GetReducedDataTypes)
 	e.GET("/data-types/variant", dataTypesMvc.GetVariantDataType)
 	e.GET("/data-types/variant/schema", dataTypesMvc.GetVariantDataTypeSchema)
 	e.GET("/data-types/variant/metadata_schema", dataTypesMvc.GetVariantDataTypeMetadataSchema)

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -134,6 +134,7 @@ func main() {
 
 	// -- Data-Types
 	e.GET("/data-types", dataTypesMvc.GetDataTypes)
+	e.GET("/public/data-types", dataTypesMvc.GetReducedDataTypes)
 	e.GET("/data-types/variant", dataTypesMvc.GetVariantDataType)
 	e.GET("/data-types/variant/schema", dataTypesMvc.GetVariantDataTypeSchema)
 	e.GET("/data-types/variant/metadata_schema", dataTypesMvc.GetVariantDataTypeMetadataSchema)

--- a/src/api/models/indexes/main.go
+++ b/src/api/models/indexes/main.go
@@ -2,6 +2,7 @@ package indexes
 
 import (
 	c "gohan/api/models/constants"
+	"time"
 )
 
 type Variant struct {
@@ -17,9 +18,10 @@ type Variant struct {
 
 	Sample Sample `json:"sample"`
 
-	FileId     string       `json:"fileId"`
-	Dataset    string       `json:"dataset"`
-	AssemblyId c.AssemblyId `json:"assemblyId"`
+	FileId      string       `json:"fileId"`
+	Dataset     string       `json:"dataset"`
+	AssemblyId  c.AssemblyId `json:"assemblyId"`
+	CreatedTime time.Time    `json:"createdTime"`
 }
 
 type Info struct {

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -50,40 +50,6 @@ func GetDataTypes(c echo.Context) error {
 	})
 }
 
-func GetReducedDataTypes(c echo.Context) error {
-	variantData, err := fetchVariantData(c)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
-			"error": err.Error(),
-		})
-	}
-
-	if variantData == nil {
-		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
-			"error": "Failed to retrieve variant data.",
-		})
-	}
-
-	count, _ := variantData["count"]
-	id, _ := variantData["id"].(string)
-	label, _ := variantData["label"].(string)
-	last_ingested, _ := variantData["last_ingested"].(string)
-	queryable, _ := variantData["queryable"].(bool)
-
-	// Create a reduced response
-	reducedResponse := map[string]interface{}{
-		"count":         count,
-		"id":            id,
-		"label":         label,
-		"last_ingested": last_ingested,
-		"queryable":     queryable,
-	}
-
-	return c.JSON(http.StatusOK, []map[string]interface{}{
-		reducedResponse,
-	})
-}
-
 func GetVariantDataType(c echo.Context) error {
 	return c.JSON(http.StatusOK, variantDataTypeJson)
 }

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -1,6 +1,7 @@
 package dataTypes
 
 import (
+	"fmt"
 	"net/http"
 
 	"gohan/api/contexts"
@@ -20,12 +21,15 @@ var variantDataTypeJson = map[string]interface{}{
 }
 
 func GetDataTypes(c echo.Context) error {
-	es := c.(*contexts.GohanContext).Es7Client
-	cfg := c.(*contexts.GohanContext).Config
+	gc := c.(*contexts.GohanContext)
+	cfg := gc.Config
+	es := gc.Es7Client
 
 	// accumulate number of variants associated with each
 	// sampleId fetched from the variants overview
 	resultsMap, err := variantService.GetVariantsOverview(es, cfg)
+
+	fmt.Printf("resultsMapDDD: %v\n", resultsMap)
 
 	if err != nil {
 		// Could not talk to Elasticsearch, return an error
@@ -35,6 +39,13 @@ func GetDataTypes(c echo.Context) error {
 	}
 
 	variantDataTypeJson["count"] = sumAllValues(resultsMap["sampleIDs"])
+
+	// Fetch the last_created value from resultsMap and add to variantDataTypeJson
+	if latestCreated, ok := resultsMap["last_created_time"].(string); ok {
+		variantDataTypeJson["last_created"] = latestCreated
+	}
+
+	fmt.Printf("variantDataTypeJson: %v\n", variantDataTypeJson)
 
 	// Data types are basically stand-ins for schema blocks
 	return c.JSON(http.StatusOK, []map[string]interface{}{

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -28,11 +28,8 @@ func fetchVariantData(c echo.Context) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	variantDataTypeJson["count"] = sumAllValues(resultsMap["sampleIDs"])
-	if latestCreated, ok := resultsMap["last_created_time"].(string); ok {
-		variantDataTypeJson["last_ingested"] = latestCreated
-	}
+	variantDataTypeJson["last_ingested"] = resultsMap["last_ingested"]
 
 	return variantDataTypeJson, nil
 }

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -29,8 +29,6 @@ func GetDataTypes(c echo.Context) error {
 	// sampleId fetched from the variants overview
 	resultsMap, err := variantService.GetVariantsOverview(es, cfg)
 
-	fmt.Printf("resultsMapDDD: %v\n", resultsMap)
-
 	if err != nil {
 		// Could not talk to Elasticsearch, return an error
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -1,7 +1,6 @@
 package dataTypes
 
 import (
-	"fmt"
 	"net/http"
 
 	"gohan/api/contexts"

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -51,9 +51,37 @@ func GetDataTypes(c echo.Context) error {
 	})
 }
 
-	// Data types are basically stand-ins for schema blocks
+func GetReducedDataTypes(c echo.Context) error {
+	variantData, err := fetchVariantData(c)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"error": err.Error(),
+		})
+	}
+
+	if variantData == nil {
+		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"error": "Failed to retrieve variant data.",
+		})
+	}
+
+	count, _ := variantData["count"]
+	id, _ := variantData["id"].(string)
+	label, _ := variantData["label"].(string)
+	last_ingested, _ := variantData["last_ingested"].(string)
+	queryable, _ := variantData["queryable"].(bool)
+
+	// Create a reduced response
+	reducedResponse := map[string]interface{}{
+		"count":         count,
+		"id":            id,
+		"label":         label,
+		"last_ingested": last_ingested,
+		"queryable":     queryable,
+	}
+
 	return c.JSON(http.StatusOK, []map[string]interface{}{
-		variantDataTypeJson,
+		reducedResponse,
 	})
 }
 

--- a/src/api/mvc/data-types/main.go
+++ b/src/api/mvc/data-types/main.go
@@ -20,30 +20,36 @@ var variantDataTypeJson = map[string]interface{}{
 	"metadata_schema": schemas.OBJECT_SCHEMA,
 }
 
-func GetDataTypes(c echo.Context) error {
+func fetchVariantData(c echo.Context) (map[string]interface{}, error) {
 	gc := c.(*contexts.GohanContext)
 	cfg := gc.Config
 	es := gc.Es7Client
 
-	// accumulate number of variants associated with each
-	// sampleId fetched from the variants overview
 	resultsMap, err := variantService.GetVariantsOverview(es, cfg)
-
 	if err != nil {
-		// Could not talk to Elasticsearch, return an error
+		return nil, err
+	}
+
+	variantDataTypeJson["count"] = sumAllValues(resultsMap["sampleIDs"])
+	if latestCreated, ok := resultsMap["last_created_time"].(string); ok {
+		variantDataTypeJson["last_ingested"] = latestCreated
+	}
+
+	return variantDataTypeJson, nil
+}
+
+func GetDataTypes(c echo.Context) error {
+	variantData, err := fetchVariantData(c)
+	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"error": err.Error(),
 		})
 	}
 
-	variantDataTypeJson["count"] = sumAllValues(resultsMap["sampleIDs"])
-
-	// Fetch the last_created value from resultsMap and add to variantDataTypeJson
-	if latestCreated, ok := resultsMap["last_created_time"].(string); ok {
-		variantDataTypeJson["last_created"] = latestCreated
-	}
-
-	fmt.Printf("variantDataTypeJson: %v\n", variantDataTypeJson)
+	return c.JSON(http.StatusOK, []map[string]interface{}{
+		variantData,
+	})
+}
 
 	// Data types are basically stand-ins for schema blocks
 	return c.JSON(http.StatusOK, []map[string]interface{}{

--- a/src/api/mvc/variants/main.go
+++ b/src/api/mvc/variants/main.go
@@ -634,24 +634,27 @@ func ClearDataset(c echo.Context) error {
 }
 
 type DataTypeSummary struct {
-	Id        string                 `json:"id"`
-	Label     string                 `json:"label"`
-	Queryable bool                   `json:"queryable"`
-	Schema    map[string]interface{} `json:"schema"`
-	Count     int                    `json:"count"`
+	Id          string                 `json:"id"`
+	Label       string                 `json:"label"`
+	Queryable   bool                   `json:"queryable"`
+	Schema      map[string]interface{} `json:"schema"`
+	Count       int                    `json:"count"`
+	LastCreated string                 `json:"last_created"`
 }
 
 type DataTypeResponseDto = []DataTypeSummary
 
 func GetDatasetDataTypes(c echo.Context) error {
 	count := GetDatasetVariantsCount(c)
+	last_created := GetLastCreatedVariantForDataset(c)
 	return c.JSON(http.StatusOK, &DataTypeResponseDto{
 		DataTypeSummary{
-			Id:        "variant",
-			Label:     "Variants",
-			Queryable: true,
-			Schema:    schemas.VARIANT_SCHEMA,
-			Count:     count,
+			Id:          "variant",
+			Label:       "Variants",
+			Queryable:   true,
+			Schema:      schemas.VARIANT_SCHEMA,
+			Count:       count,
+			LastCreated: last_created,
 		},
 	})
 }

--- a/src/api/mvc/variants/main.go
+++ b/src/api/mvc/variants/main.go
@@ -506,10 +506,6 @@ func GetLastCreatedVariantForDataset(c echo.Context) string {
 
 	g.Go(func() error {
 		timestamp, timestampError := esRepo.GetMostRecentVariantTimestamp(cfg, es, dataset.String())
-		fmt.Printf("timestamp: %v\n", timestamp)
-		fmt.Printf("timestampError: %v\n", timestampError)
-		fmt.Printf("timestampError == nil: %v\n", es)
-		fmt.Printf("timestampError == nil: %v\n", dataset.String())
 		if timestampError != nil {
 			fmt.Printf("Failed to fetch the most recent 'created' timestamp for dataset %s. Error: %v\n", dataset, timestampError)
 			return timestampError

--- a/src/api/mvc/variants/main.go
+++ b/src/api/mvc/variants/main.go
@@ -506,6 +506,10 @@ func GetLastCreatedVariantForDataset(c echo.Context) string {
 
 	g.Go(func() error {
 		timestamp, timestampError := esRepo.GetMostRecentVariantTimestamp(cfg, es, dataset.String())
+		fmt.Printf("timestamp: %v\n", timestamp)
+		fmt.Printf("timestampError: %v\n", timestampError)
+		fmt.Printf("timestampError == nil: %v\n", es)
+		fmt.Printf("timestampError == nil: %v\n", dataset.String())
 		if timestampError != nil {
 			fmt.Printf("Failed to fetch the most recent 'created' timestamp for dataset %s. Error: %v\n", dataset, timestampError)
 			return timestampError

--- a/src/api/mvc/variants/main.go
+++ b/src/api/mvc/variants/main.go
@@ -639,14 +639,14 @@ type DataTypeSummary struct {
 	Queryable   bool                   `json:"queryable"`
 	Schema      map[string]interface{} `json:"schema"`
 	Count       int                    `json:"count"`
-	LastCreated string                 `json:"last_created"`
+	LastCreated string                 `json:"last_ingested"`
 }
 
 type DataTypeResponseDto = []DataTypeSummary
 
 func GetDatasetDataTypes(c echo.Context) error {
 	count := GetDatasetVariantsCount(c)
-	last_created := GetLastCreatedVariantForDataset(c)
+	last_ingested := GetLastCreatedVariantForDataset(c)
 	return c.JSON(http.StatusOK, &DataTypeResponseDto{
 		DataTypeSummary{
 			Id:          "variant",
@@ -654,7 +654,7 @@ func GetDatasetDataTypes(c echo.Context) error {
 			Queryable:   true,
 			Schema:      schemas.VARIANT_SCHEMA,
 			Count:       count,
-			LastCreated: last_created,
+			LastCreated: last_ingested,
 		},
 	})
 }

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -604,8 +604,7 @@ func GetVariantsBucketsByKeyword(cfg *models.Config, es *elasticsearch.Client, k
 			},
 			"latest_created": map[string]interface{}{
 				"max": map[string]interface{}{
-					"field":  "createdTime",
-					"format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+					"field": "createdTime",
 				},
 			},
 		},

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -589,6 +589,7 @@ func CountDocumentsContainerVariantOrSampleIdInPositionRange(cfg *models.Config,
 
 func GetVariantsBucketsByKeyword(cfg *models.Config, es *elasticsearch.Client, keyword string) (map[string]interface{}, error) {
 	// begin building the request body.
+	fmt.Printf("Query StartKEYWORD: %s\n", keyword)
 	var buf bytes.Buffer
 	aggMap := map[string]interface{}{
 		"size": "0",
@@ -600,6 +601,12 @@ func GetVariantsBucketsByKeyword(cfg *models.Config, es *elasticsearch.Client, k
 					"order": map[string]string{
 						"_key": "asc",
 					},
+				},
+			},
+			"latest_created": map[string]interface{}{
+				"max": map[string]interface{}{
+					"field":  "createdTime",
+					"format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
 				},
 			},
 		},

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -387,12 +387,14 @@ func GetMostRecentVariantTimestamp(cfg *models.Config, es *elasticsearch.Client,
 							mostRecentTimestamp = parsedTime
 						} else {
 							fmt.Printf("Error parsing 'createdTime' timestamp: %s\n", err)
+							return mostRecentTimestamp, err
 						}
 					}
 				}
 			}
 		} else {
-			fmt.Println("No hits found for dataset:", dataset)
+			fmt.Printf("No hits found for dataset: %s\n", dataset)
+			return mostRecentTimestamp, nil
 		}
 	}
 

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -604,7 +604,7 @@ func GetVariantsBucketsByKeyword(cfg *models.Config, es *elasticsearch.Client, k
 					},
 				},
 			},
-			"latest_created": map[string]interface{}{
+			"last_ingested": map[string]interface{}{
 				"max": map[string]interface{}{
 					"field": "createdTime",
 				},
@@ -753,7 +753,6 @@ func GetVariantsBucketsByKeywordAndDataset(cfg *models.Config, es *elasticsearch
 }
 
 func DeleteVariantsByDatasetId(cfg *models.Config, es *elasticsearch.Client, dataset string) (map[string]interface{}, error) {
-
 	var buf bytes.Buffer
 	query := map[string]interface{}{
 		"query": map[string]interface{}{

--- a/src/api/repositories/elasticsearch/variants.go
+++ b/src/api/repositories/elasticsearch/variants.go
@@ -589,7 +589,6 @@ func CountDocumentsContainerVariantOrSampleIdInPositionRange(cfg *models.Config,
 
 func GetVariantsBucketsByKeyword(cfg *models.Config, es *elasticsearch.Client, keyword string) (map[string]interface{}, error) {
 	// begin building the request body.
-	fmt.Printf("Query StartKEYWORD: %s\n", keyword)
 	var buf bytes.Buffer
 	aggMap := map[string]interface{}{
 		"size": "0",

--- a/src/api/services/ingestion.go
+++ b/src/api/services/ingestion.go
@@ -827,6 +827,8 @@ func (i *IngestionService) ProcessVcf(
 					var resultingVariant indexes.Variant
 					mapstructure.Decode(tmpVariant, &resultingVariant)
 
+					resultingVariant.CreatedTime = time.Now()
+
 					// pass variant (along with a waitgroup) to the channel
 					i.IngestionBulkIndexingQueue <- &structs.IngestionQueueStructure{
 						Variant:   &resultingVariant,

--- a/src/api/services/variants/main.go
+++ b/src/api/services/variants/main.go
@@ -6,6 +6,7 @@ import (
 	"gohan/api/models"
 	esRepo "gohan/api/repositories/elasticsearch"
 	"sync"
+	"time"
 
 	"github.com/elastic/go-elasticsearch/v7"
 )
@@ -47,9 +48,12 @@ func GetVariantsOverview(es *elasticsearch.Client, cfg *models.Config) (map[stri
 		bucketsMapped := []interface{}{}
 		if aggs, aggsOk := results["aggregations"].(map[string]interface{}); aggsOk {
 			if latest, latestOk := aggs["latest_created"].(map[string]interface{}); latestOk {
-				if valueAsString, valOk := latest["value_as_string"].(string); valOk {
+				if timestamp, timeStampOk := latest["value"].(float64); timeStampOk {
+					// convert the Unix timestamp time.Time object
+					formattedTime := time.UnixMilli(int64(timestamp)).UTC().Format(time.RFC3339)
+
 					resultsMux.Lock()
-					resultsMap["last_created_time"] = valueAsString
+					resultsMap["last_created_time"] = formattedTime
 					resultsMux.Unlock()
 				}
 			}

--- a/src/api/services/variants/main.go
+++ b/src/api/services/variants/main.go
@@ -33,7 +33,6 @@ func GetVariantsOverview(es *elasticsearch.Client, cfg *models.Config) (map[stri
 		defer _wg.Done()
 
 		results, bucketsError := esRepo.GetVariantsBucketsByKeyword(cfg, es, keyword)
-		fmt.Printf("resultsCFCFCF: %v\n", results)
 		if bucketsError != nil {
 			resultsMux.Lock()
 			defer resultsMux.Unlock()

--- a/src/api/services/variants/main.go
+++ b/src/api/services/variants/main.go
@@ -31,6 +31,8 @@ func GetVariantsOverview(es *elasticsearch.Client, cfg *models.Config) (map[stri
 
 	var wg sync.WaitGroup
 
+	/* callProcessLatestCreated performs a Elasticsearch query for the latest created
+	time of variant and updates resultsMap with the formatted time.*/
 	callProcessLatestCreated := func(key string, keyword string, _wg *sync.WaitGroup) {
 		defer _wg.Done()
 

--- a/src/api/services/variants/main.go
+++ b/src/api/services/variants/main.go
@@ -81,7 +81,7 @@ func GetVariantsOverview(es *elasticsearch.Client, cfg *models.Config) (map[stri
 	}
 
 	// Extract latest created time
-	if latest, exists := resultsMap["last_created"].(map[string]interface{}); exists {
+	if latest, exists := resultsMap["last_ingested"].(map[string]interface{}); exists {
 		latestCreatedTime := latest["value_as_string"].(string)
 		resultsMap["last_created_time"] = latestCreatedTime
 	}

--- a/src/api/tests/build/api/variants_test.go
+++ b/src/api/tests/build/api/variants_test.go
@@ -169,13 +169,22 @@ func TestDemoVcfIngestion(t *testing.T) {
 		for oK, oV := range overviewJson {
 			assert.NotNil(t, oV)
 
-			assert.NotNil(t, overviewJson[oK])
-			assert.NotNil(t, overviewJson[oK].(map[string]interface{}))
+			// handle 'last_ingested' as a string
+			if oK == "last_ingested" {
+				_, ok := oV.(string)
+				assert.True(t, ok)
+				continue
+			}
 
-			for k, v := range oV.(map[string]interface{}) {
+			// assert the value is a map for other keys
+			mapValue, ok := oV.(map[string]interface{})
+			assert.True(t, ok)
+
+			for k, v := range mapValue {
 				key := k
 				assert.NotNil(t, v)
-				value := v.(float64)
+				value, ok := v.(float64)
+				assert.True(t, ok)
 				assert.NotNil(t, key)
 				assert.NotEmpty(t, key)
 				assert.NotEmpty(t, value)

--- a/src/api/tests/common/common.go
+++ b/src/api/tests/common/common.go
@@ -114,6 +114,10 @@ func GetVariantsOverview(_t *testing.T, _cfg *models.Config) map[string]interfac
 	assert.True(_t, sidkOk)
 	assert.NotNil(_t, sampleIDsKey)
 
+	lastIngestionKey, likOk := overviewRespJson["last_ingested"]
+	assert.True(_t, likOk)
+	assert.NotNil(_t, lastIngestionKey)
+
 	return overviewRespJson
 }
 


### PR DESCRIPTION
This Pull Request includes changes related to the retrieval of ingestion time for variants:

CreatedTime Metadata: With the updates in this PR, during the variant ingestion process, is captured and stored the CreatedTime for each variant. This metadata provides insights into when each variant was added.

Latest Created Field in Variants Overview: A new field named latest_created has been added to the variants overview. This field indicates the most recent creation timestamp among all variants.

Last Ingested File Information: For datasets, it is included information about the last ingested file. These changes in the GetDatasetDataTypes function provide each dataset's most recent updates.