### PR TITLE
refactor: change dataset from uuid.UUID to string (max 128 chars)

### DIFF
--- a/src/api/contexts/contexts.go
+++ b/src/api/contexts/contexts.go
@@ -7,7 +7,6 @@ import (
 	variantsService "gohan/api/services/variants"
 
 	es7 "github.com/elastic/go-elasticsearch/v7"
-	"github.com/google/uuid"
 	"github.com/labstack/echo"
 )
 
@@ -30,7 +29,7 @@ type (
 		Chromosome string
 		Genotype   constants.GenotypeQuery
 		SampleIds  []string
-		Dataset    uuid.UUID
+		Dataset    string
 		DataType   string
 		PositionBounds
 	}

--- a/src/api/middleware/datasetMiddleware.go
+++ b/src/api/middleware/datasetMiddleware.go
@@ -9,8 +9,6 @@ import (
 	"github.com/labstack/echo"
 )
 
-const maxDatasetLen = 128
-
 /*
 Echo middleware to ensure a valid `dataset` HTTP query parameter was provided
 */
@@ -19,11 +17,6 @@ func MandateDatasetAttribute(next echo.HandlerFunc) echo.HandlerFunc {
 		dataset := c.QueryParam("dataset")
 		if len(dataset) == 0 {
 			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest("missing dataset"))
-		}
-
-		if len(dataset) > maxDatasetLen {
-			fmt.Printf("Invalid dataset %s\n", dataset)
-			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset - must be at most %d characters", maxDatasetLen)))
 		}
 
 		gc := c.(*contexts.GohanContext)
@@ -38,11 +31,6 @@ func MandateDatasetPathParam(next echo.HandlerFunc) echo.HandlerFunc {
 		dataset := c.Param("dataset")
 		if len(dataset) == 0 {
 			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest("missing dataset"))
-		}
-
-		if len(dataset) > maxDatasetLen {
-			fmt.Printf("Invalid dataset %s\n", dataset)
-			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset - must be at most %d characters", maxDatasetLen)))
 		}
 
 		gc := c.(*contexts.GohanContext)
@@ -76,11 +64,6 @@ func OptionalDatasetAttribute(next echo.HandlerFunc) echo.HandlerFunc {
 
 		dataset := c.QueryParam("dataset")
 		if len(dataset) > 0 {
-			if len(dataset) > maxDatasetLen {
-				fmt.Printf("Invalid dataset %s\n", dataset)
-				return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset - must be at most %d characters", maxDatasetLen)))
-			}
-
 			gc.Dataset = dataset
 		}
 

--- a/src/api/middleware/datasetMiddleware.go
+++ b/src/api/middleware/datasetMiddleware.go
@@ -4,37 +4,30 @@ import (
 	"fmt"
 	"gohan/api/contexts"
 	"gohan/api/models/dtos/errors"
-	"gohan/api/utils"
 	"net/http"
 
-	"github.com/google/uuid"
 	"github.com/labstack/echo"
 )
+
+const maxDatasetLen = 128
 
 /*
 Echo middleware to ensure a valid `dataset` HTTP query parameter was provided
 */
 func MandateDatasetAttribute(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		// check for dataset query parameter
 		dataset := c.QueryParam("dataset")
 		if len(dataset) == 0 {
-			// if no id was provided, or is invalid, return an error
 			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest("missing dataset"))
 		}
 
-		// verify dataset is a valid UUID
-		// - assume it's a valid dataset if it's a uuid,
-		//   further verification is done later
-		if !utils.IsValidUUID(dataset) {
+		if len(dataset) > maxDatasetLen {
 			fmt.Printf("Invalid dataset %s\n", dataset)
-
-			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset %s - please provide a valid uuid", dataset)))
+			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset - must be at most %d characters", maxDatasetLen)))
 		}
 
-		// forward a type-safe value down the pipeline
 		gc := c.(*contexts.GohanContext)
-		gc.Dataset = uuid.MustParse(dataset)
+		gc.Dataset = dataset
 
 		return next(gc)
 	}
@@ -43,14 +36,17 @@ func MandateDatasetAttribute(next echo.HandlerFunc) echo.HandlerFunc {
 func MandateDatasetPathParam(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		dataset := c.Param("dataset")
-		if !utils.IsValidUUID(dataset) {
-			fmt.Printf("Invalid dataset %s\n", dataset)
+		if len(dataset) == 0 {
+			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest("missing dataset"))
+		}
 
-			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset %s - please provide a valid uuid", dataset)))
+		if len(dataset) > maxDatasetLen {
+			fmt.Printf("Invalid dataset %s\n", dataset)
+			return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset - must be at most %d characters", maxDatasetLen)))
 		}
 
 		gc := c.(*contexts.GohanContext)
-		gc.Dataset = uuid.MustParse(dataset)
+		gc.Dataset = dataset
 
 		return next(gc)
 	}
@@ -78,20 +74,14 @@ func OptionalDatasetAttribute(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		gc := c.(*contexts.GohanContext)
 
-		// check for dataset query parameter
 		dataset := c.QueryParam("dataset")
 		if len(dataset) > 0 {
-			// verify dataset is a valid UUID
-			// - assume it's a valid dataset if it's a uuid,
-			//   further verification is done later
-			if !utils.IsValidUUID(dataset) {
+			if len(dataset) > maxDatasetLen {
 				fmt.Printf("Invalid dataset %s\n", dataset)
-
-				return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset %s - please provide a valid uuid", dataset)))
+				return c.JSON(http.StatusBadRequest, errors.CreateSimpleBadRequest(fmt.Sprintf("invalid dataset - must be at most %d characters", maxDatasetLen)))
 			}
 
-			// forward a type-safe value down the pipeline
-			gc.Dataset = uuid.MustParse(dataset)
+			gc.Dataset = dataset
 		}
 
 		return next(gc)

--- a/src/api/mvc/main.go
+++ b/src/api/mvc/main.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/elastic/go-elasticsearch/v7"
-	"github.com/google/uuid"
 	"github.com/labstack/echo"
 )
 
@@ -21,10 +20,7 @@ func RetrieveCommonElements(c echo.Context) (*elasticsearch.Client, string, int,
 	upperBound := gc.UpperBound
 
 	// optional
-	datasetString := ""
-	if gc.Dataset != uuid.Nil {
-		datasetString = gc.Dataset.String()
-	}
+	datasetString := gc.Dataset
 
 	reference := c.QueryParam("reference")
 	alternative := c.QueryParam("alternative")

--- a/src/api/mvc/variants/main.go
+++ b/src/api/mvc/variants/main.go
@@ -350,7 +350,7 @@ func GetDatasetVariantsCount(c echo.Context) int {
 	g.Go(func() error {
 		docs, countError := esRepo.CountDocumentsContainerVariantOrSampleIdInPositionRange(cfg, es,
 			"*", 0, 0,
-			"", "", dataset.String(), // note : both variantId and sampleId are deliberately set to ""
+			"", "", dataset, // note : both variantId and sampleId are deliberately set to ""
 			"", "", []string{}, "", "")
 		if countError != nil {
 			fmt.Printf("Failed to count variants in dataset %s\n", dataset)
@@ -382,7 +382,7 @@ func GetLastCreatedVariantForDataset(c echo.Context) string {
 	)
 
 	g.Go(func() error {
-		timestamp, timestampError := esRepo.GetMostRecentVariantTimestamp(cfg, es, dataset.String())
+		timestamp, timestampError := esRepo.GetMostRecentVariantTimestamp(cfg, es, dataset)
 		if timestampError != nil {
 			fmt.Printf("Failed to fetch the most recent 'created' timestamp for dataset %s. Error: %v\n", dataset, timestampError)
 			return timestampError
@@ -409,7 +409,7 @@ func GetDatasetSummary(c echo.Context) error {
 	es := gc.Es7Client
 
 	dataset := gc.Dataset
-	fmt.Printf("[%s] - GetDatasetSummary hit: [%s]!\n", time.Now(), dataset.String())
+	fmt.Printf("[%s] - GetDatasetSummary hit: [%s]!\n", time.Now(), dataset)
 
 	// parallelize these two es queries
 
@@ -422,7 +422,7 @@ func GetDatasetSummary(c echo.Context) error {
 	g.Go(func() error {
 		docs, countError := esRepo.CountDocumentsContainerVariantOrSampleIdInPositionRange(cfg, es,
 			"*", 0, 0,
-			"", "", dataset.String(), // note : both variantId and sampleId are deliberately set to ""
+			"", "", dataset, // note : both variantId and sampleId are deliberately set to ""
 			"", "", []string{}, "", "")
 		if countError != nil {
 			fmt.Printf("Failed to count variants in dataset %s\n", dataset)
@@ -436,7 +436,7 @@ func GetDatasetSummary(c echo.Context) error {
 	// request #2
 	g.Go(func() error {
 		// obtain number of samples associated with this dataset
-		resultingBuckets, bucketsError := esRepo.GetVariantsBucketsByKeywordAndDataset(cfg, es, "sample.id.keyword", dataset.String())
+		resultingBuckets, bucketsError := esRepo.GetVariantsBucketsByKeywordAndDataset(cfg, es, "sample.id.keyword", dataset)
 		if bucketsError != nil {
 			fmt.Printf("Failed to bucket dataset %s variants\n", dataset)
 			return bucketsError
@@ -482,7 +482,7 @@ func ClearDataset(c echo.Context) error {
 
 	dataset := gc.Dataset
 	dataType := gc.DataType
-	fmt.Printf("[%s] - ClearDataset hit: [%s] - [%s]!\n", time.Now(), dataset.String(), dataType)
+	fmt.Printf("[%s] - ClearDataset hit: [%s] - [%s]!\n", time.Now(), dataset, dataType)
 
 	var (
 		deletionCount = 0.0
@@ -490,7 +490,7 @@ func ClearDataset(c echo.Context) error {
 	)
 	// request #1
 	g.Go(func() error {
-		deleteResponse, delErr := esRepo.DeleteVariantsByDatasetId(cfg, es, dataset.String())
+		deleteResponse, delErr := esRepo.DeleteVariantsByDatasetId(cfg, es, dataset)
 
 		if delErr != nil {
 			fmt.Printf("Failed to delete dataset %s variants\n", dataset)

--- a/src/api/services/ingestion.go
+++ b/src/api/services/ingestion.go
@@ -35,7 +35,6 @@ import (
 	"github.com/Jeffail/gabs"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esutil"
-	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -406,7 +405,7 @@ func (i *IngestionService) UploadVcfGzToDrs(cfg *models.Config, gzippedFileName 
 }
 
 func (i *IngestionService) ProcessVcf(
-	gzippedFilePath string, drsFileId string, dataset uuid.UUID,
+	gzippedFilePath string, drsFileId string, dataset string,
 	assemblyId string, filterOutReferences bool,
 	lineProcessingConcurrencyLevel int) {
 
@@ -484,7 +483,7 @@ func (i *IngestionService) ProcessVcf(
 
 			tmpVariant["fileId"] = drsFileId
 			tmpVariant["assemblyId"] = assemblyId
-			tmpVariant["dataset"] = dataset.String()
+			tmpVariant["dataset"] = dataset
 
 			// skip this call if need be
 			skipThisCall := false


### PR DESCRIPTION
## Summary

- `Dataset` field in `QueryParameters` changed from `uuid.UUID` to `string`
- Middleware now validates length ≤ 128 instead of UUID format
- All `dataset.String()` call sites updated to use `dataset` directly
- Removed `uuid` imports from `contexts`, `middleware`, `mvc/main.go`, and `ingestion.go`